### PR TITLE
Include additional maintainers for Ensmallen feedstock

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,6 @@ about:
 extra:
   recipe-maintainers:
     - marcelotrevisani
+    - zoq
+    - rcurtin
+    - coatless


### PR DESCRIPTION
Adds @zoq, @rcurtin and @coatless to maintainer list for ensmallen feedstock.